### PR TITLE
Fix config defaults not confirming to the ConfigParser prototype

### DIFF
--- a/moshy
+++ b/moshy
@@ -127,8 +127,8 @@ def parse_hostname(hostname_argument, config):
     return host_setup
 
 defaults = {
-    'cmd' : None,
-    'port' : None,
+    'cmd' : "",
+    'port' : "",
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hello,

When updating my Python to Python 3.13, Moshy has been found to start malfunctioning (read: it crashes at launch). I found the problem to boil down to the format of the default configuration set in the program (the "new" version of ConfigParser apparently needs strings). Here is a quick fix for it.

Note : I am not a Python developer, so this might by a sub-par way of fixing that.